### PR TITLE
todo: Add todo example

### DIFF
--- a/dom/checkbox_test.go
+++ b/dom/checkbox_test.go
@@ -20,17 +20,10 @@ func TestCheckboxEdit(t *testing.T) {
 	checked := dom.NewBoolStream(true)
 
 	cb.Begin()
-	elt := cb.CheckboxEdit("root", dom.Styles{}, checked)
+	elt := cb.CheckboxEdit("root", dom.Styles{Color: "red"}, checked)
 	cb.End()
 
-	// sadly attribute order is not guaranteed
-	// TODO: sort them?
-	options := map[string]bool{
-		"<input checked=\"\" type=\"checkbox\"/>": true,
-		"<input type=\"checkbox\" checked=\"\"/>": true,
-	}
-
-	if x := fmt.Sprint(elt); !options[x] {
+	if x := fmt.Sprint(elt); x != "<input checked=\"\" style=\"color: red\" type=\"checkbox\"/>" {
 		t.Error(x)
 	}
 

--- a/dom/elt.go
+++ b/dom/elt.go
@@ -43,11 +43,10 @@ type node struct {
 }
 
 func (e *node) reconcile(props Props, children []Element) Element {
+	children = e.filterNil(children)
 	if len(children) > 0 {
 		props.TextContent = ""
 	}
-
-	children = e.filterNil(children)
 
 	if e.root == nil {
 		e.root = NewElement(props, children...)

--- a/dom/elt_test.go
+++ b/dom/elt_test.go
@@ -29,11 +29,11 @@ func TestElt(t *testing.T) {
 		t.Error(x)
 	}
 
-	if x := elt("one", dom.Props{TextContent: "boo"}); x != one {
+	if x := elt("one", dom.Props{TextContent: "boouya"}); x != one {
 		t.Error("node changed", x)
 	}
 
-	if x := fmt.Sprint(one); x != "<div>boo</div>" {
+	if x := fmt.Sprint(one); x != "<div>boouya</div>" {
 		t.Error(x)
 	}
 

--- a/dom/html/html.go
+++ b/dom/html/html.go
@@ -17,10 +17,12 @@ import (
 )
 
 func init() {
-	dom.RegisterDriver(driver{})
+	dom.RegisterDriver(driver{OnChange: map[*html.Node]*dom.EventHandler{}})
 }
 
-type driver struct{}
+type driver struct {
+	OnChange map[*html.Node]*dom.EventHandler
+}
 
 func (d driver) NewElement(props dom.Props, children ...dom.Element) dom.Element {
 	tag := strings.ToLower(props.Tag)
@@ -33,7 +35,7 @@ func (d driver) NewElement(props dom.Props, children ...dom.Element) dom.Element
 		DataAtom: a,
 		Data:     a.String(),
 	}
-	elt := &element{n, nil, nil}
+	elt := element{n, &d}
 	for k, v := range props.ToMap() {
 		elt.SetProp(k, v)
 	}
@@ -46,11 +48,10 @@ func (d driver) NewElement(props dom.Props, children ...dom.Element) dom.Element
 
 type element struct {
 	*html.Node
-	OnChange *dom.EventHandler
-	children []dom.Element
+	d *driver
 }
 
-func (e *element) String() string {
+func (e element) String() string {
 	var buf bytes.Buffer
 	if err := html.Render(&buf, e.Node); err != nil {
 		panic(err)
@@ -58,13 +59,13 @@ func (e *element) String() string {
 	return buf.String()
 }
 
-func (e *element) sortAttr() {
+func (e element) sortAttr() {
 	sort.Slice(e.Node.Attr, func(i, j int) bool {
 		return e.Node.Attr[i].Key < e.Node.Attr[j].Key
 	})
 }
 
-func (e *element) SetProp(key string, value interface{}) {
+func (e element) SetProp(key string, value interface{}) {
 	defer e.sortAttr()
 	switch key {
 	case "Tag":
@@ -111,13 +112,21 @@ func (e *element) SetProp(key string, value interface{}) {
 			e.Node.Attr = append(e.Node.Attr, html.Attribute{Key: "style", Val: css})
 		}
 	case "OnChange":
-		e.OnChange = value.(*dom.EventHandler)
+		if v := value.(*dom.EventHandler); v == nil {
+			delete(e.d.OnChange, e.Node)
+		} else {
+			e.d.OnChange[e.Node] = v
+		}
 	default:
 		panic("Unknown key: " + key)
 	}
 }
 
-func (e *element) removeAttribute(key string) {
+func (e element) HTMLElement() *html.Node {
+	return e.Node
+}
+
+func (e element) removeAttribute(key string) {
 	attr := e.Node.Attr
 	for kk, a := range attr {
 		if a.Key == key {
@@ -128,7 +137,7 @@ func (e *element) removeAttribute(key string) {
 	}
 }
 
-func (e *element) Value() string {
+func (e element) Value() string {
 	checked := "off"
 	var val *string
 	inputType := ""
@@ -158,7 +167,7 @@ func (e *element) Value() string {
 	return ""
 }
 
-func (e *element) SetValue(s string) {
+func (e element) SetValue(s string) {
 	inputType := ""
 	for _, a := range e.Node.Attr {
 		switch a.Key {
@@ -173,52 +182,43 @@ func (e *element) SetValue(s string) {
 		e.SetProp("TextContent", s)
 	}
 
-	if cx := e.OnChange; cx != nil {
+	if cx, ok := e.d.OnChange[e.Node]; ok {
 		cx.Handle(dom.Event{})
 	}
 }
 
-func (e *element) Children() []dom.Element {
-	return e.children
+func (e element) Children() []dom.Element {
+	if x := e.Node.FirstChild; x != nil && x.Type == html.TextNode {
+		return nil
+	}
+
+	result := []dom.Element{}
+	for n := e.Node.FirstChild; n != nil; n = n.NextSibling {
+		result = append(result, element{n, e.d})
+	}
+	return result
 }
 
-func (e *element) RemoveChild(index int) {
-	c := make([]dom.Element, len(e.children)-1)
-	copy(c, e.children[:index])
-	copy(c[index:], e.children[index+1:])
-	e.children = c
+func (e element) RemoveChild(index int) {
 	n := e.Node.FirstChild
 	for kk := 0; kk < index; kk++ {
 		n = n.NextSibling
 	}
-	if n == nil {
-		panic(index)
-	}
 	e.Node.RemoveChild(n)
 }
 
-func (e *element) InsertChild(index int, elt dom.Element) {
-	if n := elt.(*element).Node; n.Parent == e.Node {
-		for kk, ee := range e.children {
-			if ee == elt {
-				e.RemoveChild(kk)
-			}
-		}
+func (e element) InsertChild(index int, elt dom.Element) {
+	if n := elt.(element).Node; n.Parent == e.Node {
+		e.Node.RemoveChild(n)
 	}
-
-	c := make([]dom.Element, len(e.children)+1)
-	copy(c, e.children[:index])
-	c[index] = elt
-	copy(c[index+1:], e.children[index:])
-	e.children = c
 
 	n := e.Node.FirstChild
 	for kk := 0; kk < index; kk++ {
 		n = n.NextSibling
 	}
 	if n != nil {
-		e.Node.InsertBefore(elt.(*element).Node, n)
+		e.Node.InsertBefore(elt.(element).Node, n)
 	} else {
-		e.Node.AppendChild(elt.(*element).Node)
+		e.Node.AppendChild(elt.(element).Node)
 	}
 }

--- a/dom/html/html.go
+++ b/dom/html/html.go
@@ -12,6 +12,7 @@ import (
 	"github.com/dotchain/fuss/dom"
 	"golang.org/x/net/html"
 	"golang.org/x/net/html/atom"
+	"sort"
 	"strings"
 )
 
@@ -39,6 +40,7 @@ func (d driver) NewElement(props dom.Props, children ...dom.Element) dom.Element
 	for kk, child := range children {
 		elt.InsertChild(kk, child)
 	}
+	elt.sortAttr()
 	return elt
 }
 
@@ -56,7 +58,14 @@ func (e *element) String() string {
 	return buf.String()
 }
 
+func (e *element) sortAttr() {
+	sort.Slice(e.Node.Attr, func(i, j int) bool {
+		return e.Node.Attr[i].Key < e.Node.Attr[j].Key
+	})
+}
+
 func (e *element) SetProp(key string, value interface{}) {
+	defer e.sortAttr()
 	switch key {
 	case "Tag":
 		tag := strings.ToLower(value.(string))
@@ -91,7 +100,7 @@ func (e *element) SetProp(key string, value interface{}) {
 			}
 			return
 		}
-			
+
 		if x := value.(string); x != "" {
 			e.Node.AppendChild(&html.Node{Type: html.TextNode, Data: x})
 		}

--- a/dom/text_test.go
+++ b/dom/text_test.go
@@ -19,14 +19,7 @@ func TestTextEdit(t *testing.T) {
 	elt := edit.TextEdit("root", dom.Styles{}, text)
 	edit.End()
 
-	// sadly attribute order is not guaranteed
-	// TODO: sort them?
-	options := map[string]bool{
-		"<input value=\"boo\" type=\"text\"/>": true,
-		"<input type=\"text\" value=\"boo\"/>": true,
-	}
-
-	if x := fmt.Sprint(elt); !options[x] {
+	if x := fmt.Sprint(elt); x != "<input type=\"text\" value=\"boo\"/>" {
 		t.Error(x)
 	}
 

--- a/todo/codegen.go
+++ b/todo/codegen.go
@@ -1,0 +1,46 @@
+// Copyright (C) 2019 rameshvk. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+//+build ignore
+
+package main
+
+import (
+	"github.com/dotchain/fuss/fussy"
+	"io/ioutil"
+)
+
+func main() {
+	output := "generated.go"
+	files := []string{"todo.go"}
+	info := fussy.ParseFiles(files, output)
+	info.Streams = []fussy.StreamInfo{
+		{
+			StreamType: "TaskStream",
+			ValueType:  "Task",
+			Fields: []fussy.FieldInfo{{
+				Field:            "Done",
+				FieldType:        "bool",
+				FieldStreamType:  "dom.BoolStream",
+				FieldConstructor: "dom.NewBoolStream",
+				FieldSubstream:   "DoneSubstream",
+			}, {
+				Field:            "Description",
+				FieldType:        "string",
+				FieldStreamType:  "dom.TextStream",
+				FieldConstructor: "dom.NewTextStream",
+				FieldSubstream:   "DescriptionSubstream",
+			}},
+			EntryStreamType: "",
+		},
+		{
+			StreamType:       "TasksStream",
+			ValueType:        "Tasks",
+			Fields:           nil,
+			EntryStreamType:  "TaskStream",
+			EntryConstructor: "NewTaskStream",
+		},
+	}
+	ioutil.WriteFile(output, []byte(fussy.Generate(info)), 0644)
+}

--- a/todo/generated.go
+++ b/todo/generated.go
@@ -1,0 +1,724 @@
+// Copyright (C) 2019 rameshvk. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+//
+
+package todo
+
+import (
+	"github.com/dotchain/dot/changes"
+	"github.com/dotchain/dot/refs"
+	"github.com/dotchain/fuss/core"
+	"github.com/dotchain/fuss/dom"
+)
+
+// TaskStream is a stream of Task values.
+type TaskStream struct {
+	// Notifier provides On/Off/Notify support. New instances of
+	// TaskStream created via the AppendLocal or AppendRemote
+	// share the same Notifier value.
+	*core.Notifier
+
+	// Value holds the current value. The latest value may be
+	// fetched via the Latest() method.
+	Value Task
+
+	// Change tracks the change that leads to the next value.
+	Change changes.Change
+
+	// Next tracks the next value in the stream.
+	Next *TaskStream
+}
+
+// NewTaskStream creates a new Task stream
+func NewTaskStream(value Task) *TaskStream {
+	return &TaskStream{&core.Notifier{}, value, nil, nil}
+}
+
+// Latest returns the latest value in the stream
+func (s *TaskStream) Latest() *TaskStream {
+	for s.Next != nil {
+		s = s.Next
+	}
+	return s
+}
+
+// Append appends a local change. isLocal identifies if the caller is
+// local or remote. It returns the updated stream whose value matches
+// the provided value and whose Latest() converges to the latest of
+// the stream.
+func (s *TaskStream) Append(c changes.Change, value Task, isLocal bool) *TaskStream {
+	if c == nil {
+		c = changes.Replace{Before: s.wrapValue(s.Value), After: s.wrapValue(value)}
+	}
+
+	// return value: after is correctly set to provided value
+	result := &TaskStream{Notifier: s.Notifier, Value: value}
+
+	// before tracks s, after tracks result, v tracks latest value
+	// of after chain
+	before := s
+	var v changes.Value = changes.Atomic{value}
+
+	// walk the chain of Next and find corresponding values to
+	// add to after so that both s annd after converge
+	after := result
+	for ; before.Next != nil; before = before.Next {
+		var afterChange changes.Change
+
+		if isLocal {
+			c, afterChange = before.Change.Merge(c)
+		} else {
+			afterChange, c = c.Merge(before.Change)
+		}
+
+		if c == nil {
+			// the convergence point is before.Next
+			after.Change, after.Next = afterChange, before.Next
+			return result
+		}
+
+		if afterChange == nil {
+			continue
+		}
+
+		// append this to after and continue with that
+		v = v.Apply(nil, afterChange)
+		after.Change = afterChange
+		after.Next = &TaskStream{Notifier: s.Notifier, Value: s.unwrapValue(v)}
+		after = after.Next
+	}
+
+	// append the residual change (c) to converge to wherever
+	// after has landed. Notify since s.Latest() has now changed
+	before.Change, before.Next = c, after
+	s.Notify()
+	return result
+}
+
+func (s *TaskStream) wrapValue(i interface{}) changes.Value {
+	if x, ok := i.(changes.Value); ok {
+		return x
+	}
+	return changes.Atomic{i}
+}
+
+func (s *TaskStream) unwrapValue(v changes.Value) Task {
+	if x, ok := v.(interface{}).(Task); ok {
+		return x
+	}
+	return v.(changes.Atomic).Value.(Task)
+}
+
+// SetDone updates the field with a new value
+func (s *TaskStream) SetDone(v bool) *TaskStream {
+	c := changes.Replace{s.wrapValue(s.Value.Done), s.wrapValue(v)}
+	value := s.Value
+	value.Done = v
+	key := []interface{}{"Done"}
+	return s.Append(changes.PathChange{key, c}, value, true)
+}
+
+// DoneSubstream returns a stream for Done that is automatically
+// connected to the current TaskStream instance.  Updates to one
+// automatically update the other.
+func (s *TaskStream) DoneSubstream(cache core.Cache) (field *dom.BoolStream) {
+	n := s.Notifier
+	handler := &core.Handler{nil}
+	if f, h, ok := cache.GetSubstream(n, "Done"); ok {
+		field, handler = f.(*dom.BoolStream), h
+	} else {
+		field = dom.NewBoolStream(s.Value.Done)
+		parent, merging, path := s, false, []interface{}{"Done"}
+		handler.Handle = func() {
+			if merging {
+				return
+			}
+
+			merging = true
+			for ; field.Next != nil; field = field.Next {
+				v := parent.Value
+				v.Done = field.Next.Value
+				c := changes.PathChange{path, field.Change}
+				parent = parent.Append(c, v, true)
+			}
+
+			for ; parent.Next != nil; parent = parent.Next {
+				result := refs.Merge(path, parent.Change)
+				if result == nil {
+					field = field.Append(nil, parent.Next.Value.Done, true)
+				} else {
+					field = field.Append(result.Affected, parent.Next.Value.Done, true)
+				}
+			}
+			merging = false
+		}
+		field.On(handler)
+		parent.On(handler)
+	}
+
+	handler.Handle()
+	field = field.Latest()
+	n2 := field.Notifier
+	close := func() { n.Off(handler); n2.Off(handler) }
+	cache.SetSubstream(n, "Done", field, handler, close)
+	return field
+}
+
+// SetDescription updates the field with a new value
+func (s *TaskStream) SetDescription(v string) *TaskStream {
+	c := changes.Replace{s.wrapValue(s.Value.Description), s.wrapValue(v)}
+	value := s.Value
+	value.Description = v
+	key := []interface{}{"Description"}
+	return s.Append(changes.PathChange{key, c}, value, true)
+}
+
+// DescriptionSubstream returns a stream for Description that is automatically
+// connected to the current TaskStream instance.  Updates to one
+// automatically update the other.
+func (s *TaskStream) DescriptionSubstream(cache core.Cache) (field *dom.TextStream) {
+	n := s.Notifier
+	handler := &core.Handler{nil}
+	if f, h, ok := cache.GetSubstream(n, "Description"); ok {
+		field, handler = f.(*dom.TextStream), h
+	} else {
+		field = dom.NewTextStream(s.Value.Description)
+		parent, merging, path := s, false, []interface{}{"Description"}
+		handler.Handle = func() {
+			if merging {
+				return
+			}
+
+			merging = true
+			for ; field.Next != nil; field = field.Next {
+				v := parent.Value
+				v.Description = field.Next.Value
+				c := changes.PathChange{path, field.Change}
+				parent = parent.Append(c, v, true)
+			}
+
+			for ; parent.Next != nil; parent = parent.Next {
+				result := refs.Merge(path, parent.Change)
+				if result == nil {
+					field = field.Append(nil, parent.Next.Value.Description, true)
+				} else {
+					field = field.Append(result.Affected, parent.Next.Value.Description, true)
+				}
+			}
+			merging = false
+		}
+		field.On(handler)
+		parent.On(handler)
+	}
+
+	handler.Handle()
+	field = field.Latest()
+	n2 := field.Notifier
+	close := func() { n.Off(handler); n2.Off(handler) }
+	cache.SetSubstream(n, "Description", field, handler, close)
+	return field
+}
+
+// TasksStream is a stream of Tasks values.
+type TasksStream struct {
+	// Notifier provides On/Off/Notify support. New instances of
+	// TasksStream created via the AppendLocal or AppendRemote
+	// share the same Notifier value.
+	*core.Notifier
+
+	// Value holds the current value. The latest value may be
+	// fetched via the Latest() method.
+	Value Tasks
+
+	// Change tracks the change that leads to the next value.
+	Change changes.Change
+
+	// Next tracks the next value in the stream.
+	Next *TasksStream
+}
+
+// NewTasksStream creates a new Tasks stream
+func NewTasksStream(value Tasks) *TasksStream {
+	return &TasksStream{&core.Notifier{}, value, nil, nil}
+}
+
+// Latest returns the latest value in the stream
+func (s *TasksStream) Latest() *TasksStream {
+	for s.Next != nil {
+		s = s.Next
+	}
+	return s
+}
+
+// Append appends a local change. isLocal identifies if the caller is
+// local or remote. It returns the updated stream whose value matches
+// the provided value and whose Latest() converges to the latest of
+// the stream.
+func (s *TasksStream) Append(c changes.Change, value Tasks, isLocal bool) *TasksStream {
+	if c == nil {
+		c = changes.Replace{Before: s.wrapValue(s.Value), After: s.wrapValue(value)}
+	}
+
+	// return value: after is correctly set to provided value
+	result := &TasksStream{Notifier: s.Notifier, Value: value}
+
+	// before tracks s, after tracks result, v tracks latest value
+	// of after chain
+	before := s
+	var v changes.Value = changes.Atomic{value}
+
+	// walk the chain of Next and find corresponding values to
+	// add to after so that both s annd after converge
+	after := result
+	for ; before.Next != nil; before = before.Next {
+		var afterChange changes.Change
+
+		if isLocal {
+			c, afterChange = before.Change.Merge(c)
+		} else {
+			afterChange, c = c.Merge(before.Change)
+		}
+
+		if c == nil {
+			// the convergence point is before.Next
+			after.Change, after.Next = afterChange, before.Next
+			return result
+		}
+
+		if afterChange == nil {
+			continue
+		}
+
+		// append this to after and continue with that
+		v = v.Apply(nil, afterChange)
+		after.Change = afterChange
+		after.Next = &TasksStream{Notifier: s.Notifier, Value: s.unwrapValue(v)}
+		after = after.Next
+	}
+
+	// append the residual change (c) to converge to wherever
+	// after has landed. Notify since s.Latest() has now changed
+	before.Change, before.Next = c, after
+	s.Notify()
+	return result
+}
+
+func (s *TasksStream) wrapValue(i interface{}) changes.Value {
+	if x, ok := i.(changes.Value); ok {
+		return x
+	}
+	return changes.Atomic{i}
+}
+
+func (s *TasksStream) unwrapValue(v changes.Value) Tasks {
+	if x, ok := v.(interface{}).(Tasks); ok {
+		return x
+	}
+	return v.(changes.Atomic).Value.(Tasks)
+}
+
+// Substream returns a stream for the specified index that is
+// automatically connected to the current TasksStream instance.  Updates to
+// one automatically update the other.
+func (s *TasksStream) Substream(cache core.Cache, index int) (entry *TaskStream) {
+	n := s.Notifier
+	handler := &core.Handler{nil}
+	if f, h, ok := cache.GetSubstream(n, index); ok {
+		entry, handler = f.(*TaskStream), h
+	} else {
+		entry = NewTaskStream(s.Value[index])
+		parent, merging, path := s, false, []interface{}{index}
+		handler.Handle = func() {
+			if merging {
+				return
+			}
+
+			merging = true
+			for ; entry.Next != nil; entry = entry.Next {
+				v := append(Tasks(nil), parent.Value...)
+				v[index] = entry.Next.Value
+				c := changes.PathChange{path, entry.Change}
+				parent = parent.Append(c, v, true)
+			}
+
+			for ; parent.Next != nil; parent = parent.Next {
+				result := refs.Merge(path, parent.Change)
+				var c changes.Change
+				if result != nil {
+					index = result.P[0].(int)
+					// TODO: if the index changed fix up
+					// the key in the cache
+					c = result.Affected
+				}
+				entry = entry.Append(c, parent.Next.Value[index], true)
+			}
+			merging = false
+		}
+		entry.On(handler)
+		parent.On(handler)
+	}
+
+	handler.Handle()
+	entry = entry.Latest()
+	n2 := entry.Notifier
+	close := func() { n.Off(handler); n2.Off(handler) }
+	cache.SetSubstream(n, index, entry, handler, close)
+	return entry
+}
+
+type appCtx struct {
+	core.Cache
+
+	TasksViewStruct
+	initialized  bool
+	stateHandler core.Handler
+
+	dom struct {
+		dom.CheckboxEditStruct
+		dom.EltStruct
+	}
+	memoized struct {
+		doneState    *dom.BoolStream
+		notDoneState *dom.BoolStream
+		result1      *dom.BoolStream
+		result2      *dom.BoolStream
+		result3      dom.Element
+		styles       dom.Styles
+		tasks        *TasksStream
+	}
+}
+
+func (c *appCtx) areArgsSame(styles dom.Styles, tasks *TasksStream) bool {
+
+	if styles != c.memoized.styles {
+		return false
+	}
+
+	return tasks == c.memoized.tasks
+
+}
+
+func (c *appCtx) refreshIfNeeded(styles dom.Styles, tasks *TasksStream) (result3 dom.Element) {
+	if !c.initialized || !c.areArgsSame(styles, tasks) {
+		return c.refresh(styles, tasks)
+	}
+	return c.memoized.result3
+}
+
+func (c *appCtx) refresh(styles dom.Styles, tasks *TasksStream) (result3 dom.Element) {
+	c.initialized = true
+	c.stateHandler.Handle = func() {
+		c.refresh(styles, tasks)
+	}
+
+	if c.memoized.doneState != nil {
+		c.memoized.doneState = c.memoized.doneState.Latest()
+	}
+	if c.memoized.notDoneState != nil {
+		c.memoized.notDoneState = c.memoized.notDoneState.Latest()
+	}
+	c.memoized.styles, c.memoized.tasks = styles, tasks
+
+	c.Cache.Begin()
+	defer c.Cache.End()
+
+	c.TasksViewStruct.Begin()
+	defer c.TasksViewStruct.End()
+
+	c.dom.CheckboxEditStruct.Begin()
+	defer c.dom.CheckboxEditStruct.End()
+
+	c.dom.EltStruct.Begin()
+	defer c.dom.EltStruct.End()
+	c.memoized.result1, c.memoized.result2, c.memoized.result3 = app(c, styles, tasks, c.memoized.doneState, c.memoized.notDoneState)
+
+	if c.memoized.doneState != c.memoized.result1 {
+		if c.memoized.doneState != nil {
+			c.memoized.doneState.Off(&c.stateHandler)
+		}
+		if c.memoized.result1 != nil {
+			c.memoized.result1.On(&c.stateHandler)
+		}
+		c.memoized.doneState = c.memoized.result1
+	}
+	if c.memoized.notDoneState != c.memoized.result2 {
+		if c.memoized.notDoneState != nil {
+			c.memoized.notDoneState.Off(&c.stateHandler)
+		}
+		if c.memoized.result2 != nil {
+			c.memoized.result2.On(&c.stateHandler)
+		}
+		c.memoized.notDoneState = c.memoized.result2
+	}
+	return c.memoized.result3
+}
+
+func (c *appCtx) close() {
+	c.Cache.Begin()
+	defer c.Cache.End()
+
+	c.TasksViewStruct.Begin()
+	defer c.TasksViewStruct.End()
+
+	c.dom.CheckboxEditStruct.Begin()
+	defer c.dom.CheckboxEditStruct.End()
+
+	c.dom.EltStruct.Begin()
+	defer c.dom.EltStruct.End()
+	if c.memoized.doneState != nil {
+		c.memoized.doneState.Off(&c.stateHandler)
+	}
+	if c.memoized.notDoneState != nil {
+		c.memoized.notDoneState.Off(&c.stateHandler)
+	}
+}
+
+// AppStruct is a cache for App
+// App is a thin wrapper on top of TasksView with checkboxes for ShowDone and ShowUndone
+//
+type AppStruct struct {
+	old, current map[interface{}]*appCtx
+}
+
+// Begin starts a round
+func (c *AppStruct) Begin() {
+	c.old, c.current = c.current, map[interface{}]*appCtx{}
+}
+
+// End finishes the round cleaning up any unused components
+func (c *AppStruct) End() {
+	for _, ctx := range c.old {
+		ctx.close()
+	}
+	c.old = nil
+}
+
+// App - see the type for details
+func (c *AppStruct) App(cKey interface{}, styles dom.Styles, tasks *TasksStream) (result3 dom.Element) {
+	cOld, ok := c.old[cKey]
+	if ok {
+		delete(c.old, cKey)
+	} else {
+		cOld = &appCtx{}
+	}
+	c.current[cKey] = cOld
+	return cOld.refreshIfNeeded(styles, tasks)
+}
+
+type taskEditCtx struct {
+	core.Cache
+
+	initialized  bool
+	stateHandler core.Handler
+
+	dom struct {
+		dom.CheckboxEditStruct
+		dom.EltStruct
+		dom.TextEditStruct
+	}
+	memoized struct {
+		result1 dom.Element
+		styles  dom.Styles
+		task    *TaskStream
+	}
+}
+
+func (c *taskEditCtx) areArgsSame(styles dom.Styles, task *TaskStream) bool {
+
+	if styles != c.memoized.styles {
+		return false
+	}
+
+	return task == c.memoized.task
+
+}
+
+func (c *taskEditCtx) refreshIfNeeded(styles dom.Styles, task *TaskStream) (result1 dom.Element) {
+	if !c.initialized || !c.areArgsSame(styles, task) {
+		return c.refresh(styles, task)
+	}
+	return c.memoized.result1
+}
+
+func (c *taskEditCtx) refresh(styles dom.Styles, task *TaskStream) (result1 dom.Element) {
+	c.initialized = true
+	c.stateHandler.Handle = func() {
+		c.refresh(styles, task)
+	}
+
+	c.memoized.styles, c.memoized.task = styles, task
+
+	c.Cache.Begin()
+	defer c.Cache.End()
+
+	c.dom.CheckboxEditStruct.Begin()
+	defer c.dom.CheckboxEditStruct.End()
+
+	c.dom.EltStruct.Begin()
+	defer c.dom.EltStruct.End()
+
+	c.dom.TextEditStruct.Begin()
+	defer c.dom.TextEditStruct.End()
+	c.memoized.result1 = taskEdit(c, styles, task)
+
+	return c.memoized.result1
+}
+
+func (c *taskEditCtx) close() {
+	c.Cache.Begin()
+	defer c.Cache.End()
+
+	c.dom.CheckboxEditStruct.Begin()
+	defer c.dom.CheckboxEditStruct.End()
+
+	c.dom.EltStruct.Begin()
+	defer c.dom.EltStruct.End()
+
+	c.dom.TextEditStruct.Begin()
+	defer c.dom.TextEditStruct.End()
+}
+
+// TaskEditStruct is a cache for TaskEdit
+// TaskEdit is a control that displays a task as well as allowing it
+// to be edited. The current value of the data is available in the
+// Task field (which is a stream and so supports On/Off methods).
+type TaskEditStruct struct {
+	old, current map[interface{}]*taskEditCtx
+}
+
+// Begin starts a round
+func (c *TaskEditStruct) Begin() {
+	c.old, c.current = c.current, map[interface{}]*taskEditCtx{}
+}
+
+// End finishes the round cleaning up any unused components
+func (c *TaskEditStruct) End() {
+	for _, ctx := range c.old {
+		ctx.close()
+	}
+	c.old = nil
+}
+
+// TaskEdit - see the type for details
+func (c *TaskEditStruct) TaskEdit(cKey interface{}, styles dom.Styles, task *TaskStream) (result1 dom.Element) {
+	cOld, ok := c.old[cKey]
+	if ok {
+		delete(c.old, cKey)
+	} else {
+		cOld = &taskEditCtx{}
+	}
+	c.current[cKey] = cOld
+	return cOld.refreshIfNeeded(styles, task)
+}
+
+type tasksViewCtx struct {
+	core.Cache
+
+	TaskEditStruct
+	initialized  bool
+	stateHandler core.Handler
+
+	dom struct {
+		dom.EltStruct
+	}
+	memoized struct {
+		result1     dom.Element
+		showDone    *dom.BoolStream
+		showNotDone *dom.BoolStream
+		styles      dom.Styles
+		tasks       *TasksStream
+	}
+}
+
+func (c *tasksViewCtx) areArgsSame(styles dom.Styles, showDone *dom.BoolStream, showNotDone *dom.BoolStream, tasks *TasksStream) bool {
+
+	if styles != c.memoized.styles {
+		return false
+	}
+
+	if showDone != c.memoized.showDone {
+		return false
+	}
+
+	if showNotDone != c.memoized.showNotDone {
+		return false
+	}
+
+	return tasks == c.memoized.tasks
+
+}
+
+func (c *tasksViewCtx) refreshIfNeeded(styles dom.Styles, showDone *dom.BoolStream, showNotDone *dom.BoolStream, tasks *TasksStream) (result1 dom.Element) {
+	if !c.initialized || !c.areArgsSame(styles, showDone, showNotDone, tasks) {
+		return c.refresh(styles, showDone, showNotDone, tasks)
+	}
+	return c.memoized.result1
+}
+
+func (c *tasksViewCtx) refresh(styles dom.Styles, showDone *dom.BoolStream, showNotDone *dom.BoolStream, tasks *TasksStream) (result1 dom.Element) {
+	c.initialized = true
+	c.stateHandler.Handle = func() {
+		c.refresh(styles, showDone, showNotDone, tasks)
+	}
+
+	c.memoized.styles, c.memoized.showDone, c.memoized.showNotDone, c.memoized.tasks = styles, showDone, showNotDone, tasks
+
+	c.Cache.Begin()
+	defer c.Cache.End()
+
+	c.TaskEditStruct.Begin()
+	defer c.TaskEditStruct.End()
+
+	c.dom.EltStruct.Begin()
+	defer c.dom.EltStruct.End()
+	c.memoized.result1 = tasksView(c, styles, showDone, showNotDone, tasks)
+
+	return c.memoized.result1
+}
+
+func (c *tasksViewCtx) close() {
+	c.Cache.Begin()
+	defer c.Cache.End()
+
+	c.TaskEditStruct.Begin()
+	defer c.TaskEditStruct.End()
+
+	c.dom.EltStruct.Begin()
+	defer c.dom.EltStruct.End()
+}
+
+// TasksViewStruct is a cache for TasksView
+// TasksView is a control that renders tasks using TaskEdit.
+//
+// Individual tasks can be modified underneath. The current list of
+// tasks is available via Tasks field which supports On/Off to receive
+// notifications.
+type TasksViewStruct struct {
+	old, current map[interface{}]*tasksViewCtx
+}
+
+// Begin starts a round
+func (c *TasksViewStruct) Begin() {
+	c.old, c.current = c.current, map[interface{}]*tasksViewCtx{}
+}
+
+// End finishes the round cleaning up any unused components
+func (c *TasksViewStruct) End() {
+	for _, ctx := range c.old {
+		ctx.close()
+	}
+	c.old = nil
+}
+
+// TasksView - see the type for details
+func (c *TasksViewStruct) TasksView(cKey interface{}, styles dom.Styles, showDone *dom.BoolStream, showNotDone *dom.BoolStream, tasks *TasksStream) (result1 dom.Element) {
+	cOld, ok := c.old[cKey]
+	if ok {
+		delete(c.old, cKey)
+	} else {
+		cOld = &tasksViewCtx{}
+	}
+	c.current[cKey] = cOld
+	return cOld.refreshIfNeeded(styles, showDone, showNotDone, tasks)
+}

--- a/todo/todo.go
+++ b/todo/todo.go
@@ -1,0 +1,76 @@
+// Copyright (C) 2019 rameshvk. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+// Package todo demonstrates a simple todo mvc app built with FUSS
+package todo
+
+import "github.com/dotchain/fuss/dom"
+
+// Task represents an item in the TODO list.
+type Task struct {
+	ID          string
+	Done        bool
+	Description string
+}
+
+// Tasks represents a collection of tasks
+type Tasks []Task
+
+// TaskEdit is a control that displays a task as well as allowing it
+// to be edited. The current value of the data is available in the
+// Task field (which is a stream and so supports On/Off methods).
+func taskEdit(c *taskEditCtx, styles dom.Styles, task *TaskStream) dom.Element {
+	return c.dom.Elt(
+		"root",
+		dom.Props{Tag: "div", Styles: styles},
+		c.dom.CheckboxEdit("cb", dom.Styles{}, task.DoneSubstream(c.Cache)),
+		c.dom.TextEdit("textedit", dom.Styles{}, task.DescriptionSubstream(c.Cache)),
+	)
+}
+
+// TasksView is a control that renders tasks using TaskEdit.
+//
+// Individual tasks can be modified underneath. The current list of
+// tasks is available via Tasks field which supports On/Off to receive
+// notifications.
+func tasksView(c *tasksViewCtx, styles dom.Styles, showDone *dom.BoolStream, showNotDone *dom.BoolStream, tasks *TasksStream) dom.Element {
+	return c.dom.Elt(
+		"root",
+		dom.Props{Tag: "div", Styles: styles},
+		renderTasks(tasks.Value, func(index int, t Task) dom.Element {
+			if t.Done && !showDone.Value || !t.Done && !showNotDone.Value {
+				return nil
+			}
+
+			return c.TaskEdit(t.ID, dom.Styles{}, tasks.Substream(c.Cache, index))
+		})...,
+	)
+}
+
+func renderTasks(t Tasks, fn func(int, Task) dom.Element) []dom.Element {
+	result := make([]dom.Element, len(t))
+	for kk, elt := range t {
+		result[kk] = fn(kk, elt)
+	}
+	return result
+}
+
+// App is a thin wrapper on top of TasksView with checkboxes for ShowDone and ShowUndone
+//
+func app(c *appCtx, styles dom.Styles, tasks *TasksStream, doneState *dom.BoolStream, notDoneState *dom.BoolStream) (*dom.BoolStream, *dom.BoolStream, dom.Element) {
+	if doneState == nil {
+		doneState = dom.NewBoolStream(true)
+	}
+	if notDoneState == nil {
+		notDoneState = dom.NewBoolStream(true)
+	}
+
+	return doneState, notDoneState, c.dom.Elt(
+		"root",
+		dom.Props{Tag: "div", Styles: styles},
+		c.dom.CheckboxEdit("done", dom.Styles{}, doneState),
+		c.dom.CheckboxEdit("notDone", dom.Styles{}, notDoneState),
+		c.TasksView("tasks", dom.Styles{}, doneState, notDoneState, tasks),
+	)
+}

--- a/todo/todo_test.go
+++ b/todo/todo_test.go
@@ -1,0 +1,148 @@
+// Copyright (C) 2019 rameshvk. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+package todo_test
+
+import (
+	"fmt"
+	"github.com/dotchain/fuss/dom"
+	_ "github.com/dotchain/fuss/dom/html" // html driver implementation
+	"github.com/dotchain/fuss/todo"
+	"github.com/yosssi/gohtml"
+)
+
+type setter interface {
+	SetValue(s string)
+}
+
+func Example_renderApp() {
+	tasks := todo.Tasks{
+		{"one", false, "first task"},
+		{"two", true, "second task"},
+	}
+	cache := todo.AppStruct{}
+
+	cache.Begin()
+	root := cache.App("root", dom.Styles{}, todo.NewTasksStream(tasks))
+	cache.End()
+
+	fmt.Println(gohtml.Format(fmt.Sprint(root)))
+
+	// set "ShowDone" to false which should filter out the second task
+	root.Children()[0].(setter).SetValue("off")
+	fmt.Println(gohtml.Format(fmt.Sprint(root)))
+
+	// Output:
+	// <div>
+	//   <input checked="" type="checkbox"/>
+	//   <input checked="" type="checkbox"/>
+	//   <div>
+	//     <div>
+	//       <input type="checkbox"/>
+	//       <input type="text" value="first task"/>
+	//     </div>
+	//     <div>
+	//       <input checked="" type="checkbox"/>
+	//       <input type="text" value="second task"/>
+	//     </div>
+	//   </div>
+	// </div>
+	// <div>
+	//   <input type="checkbox"/>
+	//   <input checked="" type="checkbox"/>
+	//   <div>
+	//     <div>
+	//       <input type="checkbox"/>
+	//       <input type="text" value="first task"/>
+	//     </div>
+	//   </div>
+	// </div>
+}
+
+func Example_renderTasks() {
+	cache := todo.TasksViewStruct{}
+
+	tasks := todo.Tasks{
+		{"one", false, "first task"},
+		{"two", true, "second task"},
+	}
+	s := todo.NewTasksStream(tasks)
+	showDone, showNotDone := dom.NewBoolStream(true), dom.NewBoolStream(false)
+	cache.Begin()
+	root := cache.TasksView("root", dom.Styles{}, showDone, showNotDone, s)
+	cache.End()
+	fmt.Println(gohtml.Format(fmt.Sprint(root)))
+
+	showDone = showDone.Append(nil, false, true)
+	cache.Begin()
+	root = cache.TasksView("root", dom.Styles{Color: "red"}, showDone, showNotDone, s)
+	cache.End()
+	fmt.Println(gohtml.Format(fmt.Sprint(root)))
+
+	showDone = showDone.Append(nil, true, true)
+	cache.Begin()
+	_ = cache.TasksView("root", dom.Styles{}, showDone, showNotDone, s)
+	cache.End()
+	showNotDone = showNotDone.Append(nil, true, true)
+	cache.Begin()
+	root = cache.TasksView("root", dom.Styles{}, showDone, showNotDone, s)
+	cache.End()
+	fmt.Println(gohtml.Format(fmt.Sprint(root)))
+
+	// Output:
+	// <div>
+	//   <div>
+	//     <input checked="" type="checkbox"/>
+	//     <input type="text" value="second task"/>
+	//   </div>
+	// </div>
+	// <div style="color: red">
+	// </div>
+	// <div>
+	//   <div>
+	//     <input type="checkbox"/>
+	//     <input type="text" value="first task"/>
+	//   </div>
+	//   <div>
+	//     <input checked="" type="checkbox"/>
+	//     <input type="text" value="second task"/>
+	//   </div>
+	// </div>
+}
+
+func Example_renderTask() {
+	task := todo.NewTaskStream(todo.Task{Done: false, Description: "first task"})
+	cache := todo.TaskEditStruct{}
+	cache.Begin()
+	root := cache.TaskEdit("root", dom.Styles{Color: "blue"}, task)
+	cache.End()
+	fmt.Println(gohtml.Format(fmt.Sprint(root)))
+
+	cache.Begin()
+	root = cache.TaskEdit("root", dom.Styles{Color: "red"}, task)
+	cache.End()
+	fmt.Println(gohtml.Format(fmt.Sprint(root)))
+
+	next := task.Value
+	next.Done = true
+	task = task.Append(nil, next, true)
+	cache.Begin()
+	root = cache.TaskEdit("root", dom.Styles{Color: "red"}, task)
+	cache.End()
+	fmt.Println(gohtml.Format(fmt.Sprint(root)))
+
+	// Output:
+	// <div style="color: blue">
+	//   <input type="checkbox"/>
+	//   <input type="text" value="first task"/>
+	// </div>
+	// <div style="color: red">
+	//   <input type="checkbox"/>
+	//   <input type="text" value="first task"/>
+	// </div>
+	// <div style="color: red">
+	//   <input checked="" type="checkbox"/>
+	//   <input type="text" value="first task"/>
+	// </div>
+}


### PR DESCRIPTION
This adds the todo MVC example (which rings in at 76 loc in todo.go) though this doesn't actually have the code to write  or read from the server. 

Much of the code to connect  to a server is likely to  be generated as well... so the whole app is likely to be fairly few lines to create.

The code generation is semi-automatic  right now (figuring out which streams need  to be generated is missing) and not sure if it should be automated..